### PR TITLE
Make link blue pass WCAG 2.0 contrast requirements

### DIFF
--- a/src/bring/2.Colors.md
+++ b/src/bring/2.Colors.md
@@ -72,7 +72,7 @@ name: 'Secondary'
 span: 1
 ```
 ```color
-value: '#4a90e2'
+value: '#0066dd'
 name: 'Link color'
 span: 1
 ```

--- a/src/bring/_config/variables.css
+++ b/src/bring/_config/variables.css
@@ -14,7 +14,7 @@
   --hw-color-primary-light: #b7dd98;
   --hw-color-primary-lighter: #d8ecc9;
   --hw-color-secondary: #fdbb2f;
-  --hw-color-link: #4a90e2;
+  --hw-color-link: #0066dd;
   --hw-color-avocado: #26b576;
 
   /**

--- a/src/posten/2.Colors.md
+++ b/src/posten/2.Colors.md
@@ -72,7 +72,7 @@ name: 'Secondary'
 span: 1
 ```
 ```color
-value: '#4a90e2'
+value: '#0066dd'
 name: 'Link color'
 span: 1
 ```

--- a/src/posten/_config/variables.css
+++ b/src/posten/_config/variables.css
@@ -14,7 +14,7 @@
   --hw-color-primary-light: #f98c87;
   --hw-color-primary-lighter: #fec4c2;
   --hw-color-secondary: #fdbb2f;
-  --hw-color-link: #4a90e2;
+  --hw-color-link: #0066dd;
   --hw-color-avocado: #26b576;
 
   /**


### PR DESCRIPTION
The previous link blue `#4a90e2` has lower contrast than it should have. It will fail accessibility requirements when used on the default light gray background. This new hex value `#0066dd` has the same hue, but with increased saturation and decreased lightness. 

More details in issue: https://github.com/bring/hedwig/issues/100