### PR TITLE
Add HR with lighter gray color

### DIFF
--- a/src/shared/components/hr/Hr.md
+++ b/src/shared/components/hr/Hr.md
@@ -34,6 +34,12 @@ Horizontal rule
   <hr class="hw-hr hw-hr--gray-light" />
 ```
 
+### Gray lighter
+
+```html|span-6
+  <hr class="hw-hr hw-hr--gray-lighter" />
+```
+
 ### Full
 
 ```html|span-6

--- a/src/shared/components/hr/hr.css
+++ b/src/shared/components/hr/hr.css
@@ -31,6 +31,10 @@
     background: var(--hw-color-gray-light);
   }
 
+  &--gray-lighter {
+    background: var(--hw-color-gray-lighter);
+  }
+
   &--centered {
     background: var(--hw-color-gray-lighter);
     margin: 0 auto;


### PR DESCRIPTION
This adds a styles for a <hr> component with the lighter gray-color.
<img width="499" alt="gray-lighter" src="https://user-images.githubusercontent.com/2606287/31608564-0164dd28-b271-11e7-8f88-911ad36dd7e8.png">
