### PR TITLE
Update Posten primary dark

### DIFF
--- a/src/posten/2.Colors.md
+++ b/src/posten/2.Colors.md
@@ -6,7 +6,7 @@ name: 'Primary darker'
 span: 1
 ```
 ```color
-value: '#f1302f'
+value: '#cd291f'
 name: 'Primary dark'
 span: 1
 ```

--- a/src/posten/_config/variables.css
+++ b/src/posten/_config/variables.css
@@ -9,7 +9,7 @@
    */
 
   --hw-color-primary: #e32d22;
-  --hw-color-primary-dark: #f1302f;
+  --hw-color-primary-dark: #cd291f;
   --hw-color-primary-darker: #562022;
   --hw-color-primary-light: #f98c87;
   --hw-color-primary-lighter: #fec4c2;


### PR DESCRIPTION
According to Ingrid Arnesen, the primary dark color should be #CD291F.

<img width="554" alt="sd" src="https://user-images.githubusercontent.com/2606287/31760695-d4aaeeac-b4b5-11e7-8617-3fa0ee791a3c.png">