### PR TITLE
Set sans-serif as default fallback font

### DIFF
--- a/src/shared/_config/variables.css
+++ b/src/shared/_config/variables.css
@@ -47,9 +47,9 @@
    * Fonts
    */
 
-  --hw-font-primary-regular: 'Foundry Monoline Regular';
-  --hw-font-primary-medium: 'Foundry Monoline Medium';
-  --hw-font-primary-bold: 'Foundry Monoline Bold';
+  --hw-font-primary-regular: 'Foundry Monoline Regular', sans-serif;
+  --hw-font-primary-medium: 'Foundry Monoline Medium', sans-serif;
+  --hw-font-primary-bold: 'Foundry Monoline Bold', sans-serif;
 
   /**
    * Font sizes


### PR DESCRIPTION
We have an issue in New Sende in the Native application where we don't want to use the Posten-font (Foundry Monoline), but we want to use a normal sans-serif font.

Without this added line, the font will fallback to a serif font which looks kinda terrible.