### PR TITLE
There's a build-in env-var for that.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,19 +21,19 @@
   "main": "index.js",
   "scripts": {
     "dev": "concurrently \"npm run watcher\" \"npm run serve\"",
-    "build": "npm run getversion && npm run docs:build && npm run css:build && npm run js:build",
+    "build": "npm run docs:build && npm run css:build && npm run js:build",
     "build:test": "npm run css:build:test && npm run js:build:test",
     "css:dev": "npm run css:dev:bring & npm run css:dev:posten",
     "css:dev:bring": "postcss tmp/bring.css --use postcss-cssnext postcss-extend -o ./build/bring.css",
     "css:dev:posten": "postcss tmp/posten.css --use postcss-cssnext postcss-extend -o ./build/posten.css",
     "css:build": "npm run css:build:bring & npm run css:build:posten",
     "css:build:test": "npm run css:build:bring:test & npm run css:build:posten:test",
-    "css:build:bring": "VERSION=$(cat tmp/.version) && postcss tmp/bring.css --no-map --use postcss-cssnext postcss-extend cssnano -o ./build/releases/bring-$VERSION.css",
+    "css:build:bring": "postcss tmp/bring.css --no-map --use postcss-cssnext postcss-extend cssnano -o ./build/releases/bring-${npm_package_version}.css",
     "css:build:bring:test": "postcss tmp/bring.css --no-map --use postcss-cssnext postcss-extend cssnano -o ./build/releases/bring-test.css",
-    "css:build:posten": "VERSION=$(cat tmp/.version) && postcss tmp/posten.css --no-map --use postcss-cssnext postcss-extend cssnano -o ./build/releases/posten-$VERSION.css",
+    "css:build:posten": "postcss tmp/posten.css --no-map --use postcss-cssnext postcss-extend cssnano -o ./build/releases/posten-${npm_package_version}.css",
     "css:build:posten:test": "postcss tmp/posten.css --no-map --use postcss-cssnext postcss-extend cssnano -o ./build/releases/posten-test.css",
     "js:dev": "rollup -c --name \"hedwig\"",
-    "js:build": "VERSION=$(cat tmp/.version) && rollup -c --name \"hedwig\" --output build/releases/main-$VERSION.js",
+    "js:build": "rollup -c --name \"hedwig\" --output build/releases/main-${npm_package_version}.js",
     "js:build:test": "rollup -c --name \"hedwig\" --output build/releases/main-test.js",
     "docs:build": "node ./scripts/docs-build",
     "watcher": "node ./scripts/watcher",
@@ -48,8 +48,7 @@
     "svg:sprite": "node ./scripts/svg-sprite",
     "svg": "npm run svg:min && npm run svg:sprite",
     "css:fix": "stylelint 'src/**/*.css' --fix",
-    "getversion": "echo $(cat package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[\",]//g' | tr -d '[[:space:]]') > tmp/.version",
-    "postpublish": "npm run getversion && VERSION=$(cat tmp/.version) && git tag $VERSION && git push --tags"
+    "postpublish": "git tag ${npm_package_version} && git push --tags"
   },
   "dependencies": {
     "aws-sdk": "^2.40.0",


### PR DESCRIPTION
`npm run[-script]` exposes the version number from `package.json` as a environment variable called `$npm_package_version` (see `npm run env` for a full list). This pull requests simplifies the run targets by using this variable and removes the therefor obsolete script `getversion`.