### PR TITLE
Block tweaks

### DIFF
--- a/src/shared/components/autocomplete/autocomplete.css
+++ b/src/shared/components/autocomplete/autocomplete.css
@@ -110,7 +110,7 @@
     background: #fff;
     border: 3px solid var(--hw-color-gray-darker);
     overflow-y: scroll;
-    z-index: 1;
+    z-index: 2;
   }
 
   &__suggestion {

--- a/src/shared/components/list/List.md
+++ b/src/shared/components/list/List.md
@@ -39,3 +39,13 @@ Various list styles
   <li>List item</li>
 </ul>
 ```
+
+## Light List
+
+```html
+<ul class="hw-list hw-list--light">
+  <li>List item</li>
+  <li>List item</li>
+  <li>List item</li>
+</ul>
+```

--- a/src/shared/components/list/list.css
+++ b/src/shared/components/list/list.css
@@ -14,7 +14,7 @@
   }
 
   & li::before {
-    content: '';
+    content: "";
     position: absolute;
     background: var(--hw-color-gray-light);
     width: 10px;
@@ -51,5 +51,9 @@
     & li::before {
       display: none;
     }
+  }
+
+  &--light {
+    font-family: var(--hw-font-primary-regular);
   }
 }

--- a/src/shared/layout/block/Block.md
+++ b/src/shared/layout/block/Block.md
@@ -64,6 +64,16 @@ The only exception to this rule is "rich text" areas from the CMS, for this case
   </div>
 ```
 
+### Responsive block (px)
+
+```html|span-6,responsive
+  <div class="hw-helpers-margin-highlighter">
+    <div class="hw-block hw-block--px">
+      <p>Default container</p>
+    </div>
+  </div>
+```
+
 ### Variants (Alternating)
 
 ```html|span-4,plain,light
@@ -84,7 +94,7 @@ The only exception to this rule is "rich text" areas from the CMS, for this case
 ### Block modifiers (margin & padding)
 
 ```code
-[Padding sides]             .hw-block-px
+[Padding sides]             .hw-block--px
 [Margin top]                .hw-block--mt
 [Small margin top]          .hw-block--mt-small
 [Large margin top]          .hw-block--mt-large

--- a/src/shared/layout/block/Block.md
+++ b/src/shared/layout/block/Block.md
@@ -69,7 +69,12 @@ The only exception to this rule is "rich text" areas from the CMS, for this case
 ```html|span-6,responsive
   <div class="hw-helpers-margin-highlighter">
     <div class="hw-block hw-block--px">
-      <p>Default container</p>
+      <p>Default px block</p>
+    </div>
+  </div>
+  <div class="hw-helpers-margin-highlighter">
+    <div class="hw-block hw-block--px-fluid">
+      <p>Fluid px block</p>
     </div>
   </div>
 ```
@@ -95,6 +100,7 @@ The only exception to this rule is "rich text" areas from the CMS, for this case
 
 ```code
 [Padding sides]             .hw-block--px
+[Fluid Padding sides]       .hw-block--px-fluid
 [Margin top]                .hw-block--mt
 [Small margin top]          .hw-block--mt-small
 [Large margin top]          .hw-block--mt-large

--- a/src/shared/layout/block/block.css
+++ b/src/shared/layout/block/block.css
@@ -9,10 +9,6 @@
    * Modifiers: padding and padding variations
    */
 
-  &--px {
-    padding: 0 var(--hw-spacing);
-  }
-
   &--mt {
     margin-top: var(--hw-spacing);
   }
@@ -159,5 +155,23 @@
 
   &--relative {
     position: relative;
+  }
+
+  &--px-fixed {
+    padding: 0 var(--hw-spacing-smaller);
+  }
+
+  /**
+   * Modifiers: Responsive gutter
+   */
+
+  &--px {
+    padding: 0 var(--hw-spacing-smaller);
+  }
+}
+
+@media (--medium) {
+  .hw-block--px {
+    padding: 0 var(--hw-spacing-large);
   }
 }

--- a/src/shared/layout/block/block.css
+++ b/src/shared/layout/block/block.css
@@ -157,21 +157,21 @@
     position: relative;
   }
 
-  &--px-fixed {
-    padding: 0 var(--hw-spacing-smaller);
+  &--px {
+    padding: 0 var(--hw-spacing);
   }
 
   /**
    * Modifiers: Responsive gutter
    */
 
-  &--px {
+  &--px-fluid {
     padding: 0 var(--hw-spacing-smaller);
   }
 }
 
 @media (--medium) {
-  .hw-block--px {
+  .hw-block--px-fluid {
     padding: 0 var(--hw-spacing-large);
   }
 }


### PR DESCRIPTION
Added a new modifier to the block:

`.hw-block--px-fluid`

This behaves just like a container, so that it can be used to create the same side gutters, for example inside a gray box. Example:

![image](https://user-images.githubusercontent.com/4840600/46081751-96460e80-c19d-11e8-802c-b0bce74e9186.png)
