### PR TITLE
Fix display of placeholder for dropdown within a drawer

### DIFF
--- a/src/shared/components/dropdown/dropdown.js
+++ b/src/shared/components/dropdown/dropdown.js
@@ -60,10 +60,10 @@ export const HWDropdown = ({
         option.dataset.hwDropdownOptionSelected = true;
         // Set selected value in either input-placeholder or div-placeholder
         if (isSearchable === 'true') {
-          placeHolderEl.placeholder = customPlaceholder || option.innerText;
+          placeHolderEl.placeholder = customPlaceholder || option.innerText.trim();
           placeHolderEl.value = option.innerText;
         } else {
-          placeHolderEl.innerText = customPlaceholder || option.innerText;
+          placeHolderEl.innerText = customPlaceholder || option.innerText.trim();
         }
       } else {
         option.dataset.hwDropdownOptionSelected = false;


### PR DESCRIPTION
It turns out that option.innerText has some extra whitespace while display = none.
This extra whitespace, somehow, gets converted into <br>s while assigning it to another element's innerText
Therefore .trim() is used to shave off the extra whitespace