### PR TITLE
Cleanup and change hover for Icon link

### DIFF
--- a/src/shared/components/icon-link/Icon-link.md
+++ b/src/shared/components/icon-link/Icon-link.md
@@ -8,39 +8,9 @@
 </a>
 ```
 
-### Example gray
-```html|span-2
-<a class="hw-icon-link hw-icon-link--gray" href="#">
-  <svg class="hw-icon">
-    <use xlink:href="#bud"></use>
-  </svg>
-  <span class="hw-icon-link__text">Here is the link text</span>
-</a>
-```
-
-### Example white
-```html|span-2,dark
-<a class="hw-icon-link hw-icon-link--white" href="#">
-  <svg class="hw-icon">
-    <use xlink:href="#bud"></use>
-  </svg>
-  <span class="hw-icon-link__text">Here is the link text</span>
-</a>
-```
-
 ### Example with border
 ```html|span-2
 <a class="hw-icon-link hw-icon-link--border" href="#">
-  <svg class="hw-icon">
-    <use xlink:href="#bud"></use>
-  </svg>
-  <span class="hw-icon-link__text">Here is the link text</span>
-</a>
-```
-
-### Example gray with border
-```html|span-2
-<a class="hw-icon-link hw-icon-link--border hw-icon-link--gray" href="#">
   <svg class="hw-icon">
     <use xlink:href="#bud"></use>
   </svg>
@@ -78,28 +48,28 @@
 </div>
 ```
 
-### Example in flex gray with border
+### Example in flex with border
 ```html
 <div class="hw-flex hw-flex--guttered">
-  <a class="hw-icon-link hw-icon-link--gray hw-icon-link--border" href="#">
+  <a class="hw-icon-link hw-icon-link--border" href="#">
     <svg class="hw-icon">
       <use xlink:href="#adresseendringogoppbevaring"></use>
     </svg>
     <span class="hw-icon-link__text">Adresseendring og oppbevaring</span>
   </a>
-  <a class="hw-icon-link hw-icon-link--gray hw-icon-link--border" href="#">
+  <a class="hw-icon-link hw-icon-link--border" href="#">
     <svg class="hw-icon">
       <use xlink:href="#brev"></use>
     </svg>
     <span class="hw-icon-link__text">Pakker og brev</span>
   </a>
-  <a class="hw-icon-link hw-icon-link--gray hw-icon-link--border" href="#">
+  <a class="hw-icon-link hw-icon-link--border" href="#">
     <svg class="hw-icon">
       <use xlink:href="#sporing"></use>
     </svg>
     <span class="hw-icon-link__text">Sporing</span>
   </a>
-  <a class="hw-icon-link hw-icon-link--gray hw-icon-link--border" href="#">
+  <a class="hw-icon-link hw-icon-link--border" href="#">
     <svg class="hw-icon">
       <use xlink:href="#toll"></use>
     </svg>

--- a/src/shared/components/icon-link/icon-link.css
+++ b/src/shared/components/icon-link/icon-link.css
@@ -1,22 +1,15 @@
 .hw-icon-link {
   padding: var(--hw-spacing);
   display: block;
-  color: var(--hw-color-link);
+  color: var(--hw-color-gray-darkest);
   text-align: center;
-  transition: color 0.3s ease;
+  transition: background-color 0.3s ease, border-color 0.3s ease;
+
   & .hw-icon {
     margin: 0 auto var(--hw-spacing);
     width: 74px;
     height: var(--hw-spacing-larger);
     display: block;
-  }
-
-  &--gray {
-    color: var(--hw-color-gray-darkest);
-  }
-
-  &--white {
-    color: var(--hw-color-white);
   }
 
   &--border {
@@ -25,25 +18,7 @@
   }
 
   &:hover {
-    color: var(--hw-color-gray-darkest);
+    background-color: rgba(0,0,0,0.04);
     border-color: var(--hw-color-gray-light);
-    & .hw-icon-link__text {
-      border-bottom: 2px solid var(--hw-color-gray-darkest);
-    }
   }
-
-  &--gray:hover {
-    color: var(--hw-color-link);
-    & .hw-icon-link__text {
-      border-bottom: 2px solid var(--hw-color-link-underline);
-    }
-  }
-
-  &--white:hover {
-    color: var(--hw-color-white);
-    & .hw-icon-link__text {
-      border-bottom: 2px solid var(--hw-color-white);
-    }
-  }
-
 }


### PR DESCRIPTION
- Background color 4% black on hover
- Remove white- and link-colored versions