### PR TITLE
Add sizing modifier for hw-icon

### DIFF
--- a/src/shared/components/icon-service/Icon-service.md
+++ b/src/shared/components/icon-service/Icon-service.md
@@ -32,15 +32,16 @@ See [Examples of including](#examples-of-including)
 
 
 ### Sizing
-Hedwig does not deliver sizing for service icons
-You can size service icons by directly setting width and height.
+
+Service icons does not have a default size
+There is a size modifier: `hw-icon--size-medium`
 ```code
-<svg class="hw-icon" style="width: 100px; height: 100px">
+<svg class="hw-icon hw-icon--size-medium">
     <use xlink:href="#bud"></use>
 </svg>
 ```
 ```html
-<svg class="hw-icon" style="width: 100px; height: 100px">
+<svg class="hw-icon hw-icon--size-medium">
     <use xlink:href="#bud"></use>
 </svg>
 ```

--- a/src/shared/components/icon-service/icon-service.css
+++ b/src/shared/components/icon-service/icon-service.css
@@ -9,23 +9,9 @@
    * Modifiers
    */
 
-  &--primary {
-    fill: var(--hw-color-primary);
-  }
-
-  &--green {
-    fill: var(--hw-color-green);
-  }
-
-  &--red {
-    fill: var(--hw-color-red);
-  }
-
-  &--gray-lighter {
-    fill: var(--hw-color-gray-lighter);
-  }
-
-  &--gray-darker {
-    fill: var(--hw-color-gray-darker);
+  &--size-medium {
+    min-width: 30px;
+    width: 30px;
+    height: 30px;
   }
 }


### PR DESCRIPTION
Remove icon specific coloring. This is provided through `hw-color-[color]`