### PR TITLE
Bug fix: Show figcaption only if content present

### DIFF
--- a/src/shared/components/figure/figure.css
+++ b/src/shared/components/figure/figure.css
@@ -26,7 +26,7 @@
     text-align: left;
   }
 
-  &__figcaption::before {
+  &__figcaption:not(:empty)::before {
     content: '';
     display: inline-block;
     margin-right: var(--hw-spacing-smallest);


### PR DESCRIPTION
enonic adds caption even if no captions are there