### PR TITLE
Fix link from layout to grid page and spelling

### DIFF
--- a/src/shared/components/input/Input.md
+++ b/src/shared/components/input/Input.md
@@ -1,6 +1,6 @@
 ## Input fields
 
-All inputs are block elements. For layout, use [grid]('/Grid').
+All inputs are block elements. For layout, use [grid](/Grid).
 
 ```html
 <label class="hw-label">

--- a/src/shared/guidelines/Layout.md
+++ b/src/shared/guidelines/Layout.md
@@ -1,6 +1,6 @@
 ## Composing pages and components
 
-When building new components, concider using [containers](/Container) and [blocks](/Block) to maintain consistent margins and paddings:
+When building new components, consider using [containers](/Container) and [blocks](/Block) to maintain consistent margins and paddings:
 
 #### Example 1:
 


### PR DESCRIPTION
Fixed a small spelling mistake in layout.md and removed '' around
relative link in the input.md file as it caused the link to not work properly