### PR TITLE
Prefix for phone number must be long enough

### DIFF
--- a/src/shared/components/phone-input/Phone-input.md
+++ b/src/shared/components/phone-input/Phone-input.md
@@ -28,6 +28,7 @@ This is because this is technically two form fields.
         <option data-hw-dropdown-placeholder="+483" value="8">+48 Sverige</option>
         <option data-hw-dropdown-placeholder="+49" value="10">+49 Finland</option>
         <option data-hw-dropdown-placeholder="+498" value="11">+498 USA</option>
+        <option data-hw-dropdown-placeholder="+4981" value="12">+4981 Narnia</option>
       </select>
       <input class="hw-input" type="tel" />
     </div>
@@ -53,6 +54,7 @@ This is because this is technically two form fields.
         <option data-hw-dropdown-placeholder="+483" value="8">+48 Sverige</option>
         <option data-hw-dropdown-placeholder="+49" value="10">+49 Finland</option>
         <option data-hw-dropdown-placeholder="+498" value="11">+498 USA</option>
+        <option data-hw-dropdown-placeholder="+4981" value="12">+4981 Narnia</option>
       </select>
       <input class="hw-input" type="tel" />
     </div>

--- a/src/shared/components/phone-input/phone-input.css
+++ b/src/shared/components/phone-input/phone-input.css
@@ -114,7 +114,7 @@
           display: block;
         }
       }
-      
+
       & .hw-dropdown__options {
         display: block;
       }
@@ -126,10 +126,10 @@
     &--transition .hw-dropdown__placeholder{
       display: block;
     }
-    &--native{ 
+    &--native{
       border-right: none;
       margin: 0;
-      flex-basis: 100px;
+      flex-basis: 120px;
       background-position: calc(100% - 14px) 40%;
       & ~ .hw-input{
         padding: 12px 12px 12px 0;


### PR DESCRIPTION
Prefix for phone number must be long enough to support country codes that are five characters long (e.g "+1806")