### PR TITLE
Add closing div to navbar without menu example

### DIFF
--- a/src/bring/components/navbar/Navbar.md
+++ b/src/bring/components/navbar/Navbar.md
@@ -554,6 +554,7 @@ On this page, only the first navbar is able to open the search, menu and login. 
         </svg>
       </a>
     </div>
+  </div>
 </header>
 ```
 

--- a/src/posten/components/navbar/Navbar.md
+++ b/src/posten/components/navbar/Navbar.md
@@ -555,6 +555,7 @@ On this page, only the first navbar is able to open the search, menu and login. 
         </svg>
       </a>
     </div>
+  </div>
 </header>
 ```
 


### PR DESCRIPTION
The code example for navbar without menu lacked a closing div