### PR TITLE
add a no-underline without hover modifier to hw-link

### DIFF
--- a/src/shared/components/link/Link.md
+++ b/src/shared/components/link/Link.md
@@ -33,3 +33,7 @@ Default link styles
 ```html|span-6,dark
   <a href="#" class="hw-link hw-link--inverted">This is an inverted link</a>
 ```
+
+```html|span-6
+  <a href="#" class="hw-link hw-link--no-underline">This is a link without an underline until hovered</a>
+```

--- a/src/shared/components/link/link.css
+++ b/src/shared/components/link/link.css
@@ -46,4 +46,11 @@
   &--big {
     font-size: var(--hw-font-size-h3);
   }
+
+  &--no-underline {
+    border-bottom-width: 0px;
+    &:hover {
+      border-bottom-width: 2px;
+    }
+  }
 }


### PR DESCRIPTION
Request for a modifier that would hide the underline of links until
they are hovered. This modifier works together with other classes,
as all it does is affect the border-bottom-width attribute.
A demonstration was also added to the documentation.