### PR TITLE
start the print section of Hedwig

### DIFF
--- a/src/shared/_config/variables.css
+++ b/src/shared/_config/variables.css
@@ -125,6 +125,9 @@
   /* For high resolution mobiles */
   @custom-media --high-res-mobile (orientation: portrait) and (-webkit-min-device-pixel-ratio: 2) and (max-device-width: 939px) ;
 
+  /* For print and/or screen */
+  @custom-media --print print;
+  @custom-media --screen screen;
 
   /* Navbar heights */
   --hw-navbar-height-mobile: 54px;

--- a/src/shared/components/print/Print.md
+++ b/src/shared/components/print/Print.md
@@ -1,0 +1,79 @@
+## Print
+
+How components and elements will be presented and work in print view
+
+The following original classes are affected by default for the print view 
+```code
+nav                       Hidden
+.hw-navbar                Hidden
+.hw-footer__desktop       Hidden
+.hw-footer__mobile        Hidden
+.hw-mobile-only           Hidden
+.hw-desktop-only          Hidden
+.hw-button                Hidden
+.hw-list                  Default view
+.hw-accordion__item       Expanded
+```
+
+### Utilities
+
+There are some new [Utilities](/Utilities) available
+```code
+[Hidden in print]                 .hw-print-hidden
+[Show as block in print]          .hw-print-show-block
+[Show as inline in print]         .hw-print-show-inline
+[Show as flex in print]           .hw-print-show-flex
+[Show as inline-block in print]   .hw-print-show-inline-block { display: inline-block; }
+
+[Page break before element]        .hw-print-break-before
+[Page break after element]         .hw-print-break-after
+[Do not page break around element] .hw-print-no-break
+
+```
+
+### Navbar
+
+The [Navbar](/Navbar), as well as `<nav>` elements will be hidden by default in print mode.
+This is due to them being set to `display: hidden` in the print view, as a navigation is deemed
+useless on a printed page.
+
+### Footer
+
+The [Footer](/Footer) will be partially hidden by default in print mode.
+This is due to `hw-footer__desktop` and `hw-footer__mobile` being set to `display: hidden` in the
+print view, as they are deemed to serve no purpose on a printed page, but the copyright segment
+should still be visible.
+
+### Buttons
+
+[Buttons](/Buttons) will be hidden by default in print view, as they lack functionality on a printed
+page.
+
+### Lists
+
+[List](/List) elements will look slightly different in print view. This is due to image-base list
+icons not being supported by print view by default. So lists will be displayed with the default
+disc mode in print view.
+
+### Accordions
+
+[Accordion](/Accordion) components will be expanded by default, so that all data and/or information
+inside will be visible, and not obscured, in print view. 
+
+#### Example
+
+```html|span-6
+  <ul class="hw-accordion" data-hw-accordion>
+    <li class="hw-accordion__item">
+      <button class="hw-accordion__trigger">
+        Try viewing this in print as both opened and closed.
+        <div class="hw-accordion__arrow"></div>
+      </button>
+      <div class="hw-accordion__contents">
+        <div class="hw-wysiwyg hw-wysiwyg--small">
+          <p>You will notice that even when closed, this line will be visible in print view.</p>
+      </div>
+    </div>
+    </li>
+  </ul>
+```

--- a/src/shared/components/print/print.css
+++ b/src/shared/components/print/print.css
@@ -1,0 +1,17 @@
+@media print {
+  nav,
+  .hw-navbar,
+  .hw-footer__desktop,
+  .hw-footer__mobile,
+  .hw-button { display: none; }
+
+  .hw-list,
+  .hw-wysiwyg ol,
+  .hw-wysiwyg ul { list-style: disc; }
+
+  .hw-list li::before,
+  .hw-wysiwyg ol li::before,
+  .hw-wysiwyg ul li::before { display: none; }
+
+  .hw-accordion__item { height: auto !important; }
+}

--- a/src/shared/guidelines/Utilities.md
+++ b/src/shared/guidelines/Utilities.md
@@ -15,20 +15,49 @@ Gives the set display properties on certain elements. Eg: hiding input fields in
 Responsive hide classes can be used to restrict the display of content to a certain viewport size.
 The available sizes are mobile/tablet and desktop
 
-### Exapmles
+### Examples
 ```code
 [Mobile/tablet]       .hw-mobile-only
 [Desktop]             .hw-desktop-only
+[Print]               .hw-print-only
+[Screen]              .hw-screen-only
 ```
 
 ```html|span-6,responsive
   <div class="hw-block hw-block--mb hw-mobile-only">
-    
-      <p class="hw-helpers-highlight">Display only on mobile/tablet</p>
-    </div>
+    <p class="hw-helpers-highlight">Display only on mobile/tablet</p>
+  </div>
 
-   <div class="hw-block hw-desktop-only">
-      <p class="hw-helpers-highlight">Display only on desktop</p>
-    </div>
+  <div class="hw-block hw-desktop-only">
+    <p class="hw-helpers-highlight">Display only on desktop</p>
+  </div>
   
+  <div class="hw-block hw-print-only">
+    <p class="hw-helpers-highlight">Display only on print, not on screen</p>
+  </div>
+  
+  <div class="hw-block hw-screen-only">
+    <p class="hw-helpers-highlight">Display only on screens, not in print</p>
+  </div>
+  
+```
+
+## Print
+
+### Print view utilities
+
+There are a few utilities to help shape and tweak the print view for a page. They range from hiding
+elements from view, to fixing where the is a page break when printing
+
+```code
+[Hidden in print]                 .hw-print-hidden
+[Show as block in print]          .hw-print-show-block
+[Show as inline in print]         .hw-print-show-inline
+[Show as flex in print]           .hw-print-show-flex
+[Show as inline-block in print]   .hw-print-show-inline-block { display: inline-block; }
+
+[Page break before element]        .hw-print-break-before
+[Page break after element]         .hw-print-break-after
+[Do not page break around element] .hw-print-no-break
+
 ```

--- a/src/shared/utilities/css/print.css
+++ b/src/shared/utilities/css/print.css
@@ -1,0 +1,15 @@
+@media print {
+  .hw-print-hidden { display: none; }
+  .hw-print-show-block { display: block; }
+  .hw-print-show-inline { display: inline; }
+  .hw-print-show-flex { display: flex; }
+  .hw-print-show-inline-block { display: inline-block; }
+
+  .hw-print-break-before { page-break-before: always; }
+  .hw-print-break-after { page-break-after: always; }
+
+  .hw-print-no-break {
+    page-break-before: avoid;
+    page-break-after: avoid;
+  }
+}

--- a/src/shared/utilities/css/responsive.css
+++ b/src/shared/utilities/css/responsive.css
@@ -16,3 +16,13 @@
   }
  }
 
+@media print {
+  .hw-desktop-only,
+  .hw-mobile-only,
+  .hw-screen-only { display: none; }
+}
+
+@media screen {
+  .hw-print-only { display: none; }
+}
+


### PR DESCRIPTION
A request came up in kp-suite about printed pages, which led to a
decision to start adapting Hedwig with some print functionality. These
is the initial features that will be included for print views:

- Automatically hide elements that are non-functional in print
  (e.g. menu, footer links, buttons)
- Automatically expand accordions
- Hide mobile-only and desktop-only elements
- Screen-only class
- Print-only class
- Print view display modifiers
- Page breaks utilities
- Documentation