### PR TITLE
Bump @babel/cli and @babel/preset-env to 7.6.0 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,8 +82,8 @@
     "npm": "6.9.0"
   },
   "devDependencies": {
-    "@babel/cli": "^7.5.5",
-    "@babel/preset-env": "^7.5.5",
+    "@babel/cli": "^7.6.0",
+    "@babel/preset-env": "^7.6.0",
     "@fortawesome/fontawesome-svg-core": "^1.2.22",
     "@fortawesome/free-brands-svg-icons": "^5.10.2",
     "@fortawesome/pro-light-svg-icons": "^5.10.2",


### PR DESCRIPTION
after being bumped by Dependabot in package-lock.json