### PR TITLE
modifying Array.from polyfill so it works in IE11

### DIFF
--- a/src/shared/utilities/js/polyfills/array-from.js
+++ b/src/shared/utilities/js/polyfills/array-from.js
@@ -1,5 +1,5 @@
 // Production steps of ECMA-262, Edition 6, 22.1.2.1
-if (!Array.from) {
+if (!typeof(Array.from) !== 'function') {
   Array.from = (function () {
     var toStr = Object.prototype.toString;
     var isCallable = function (fn) {


### PR DESCRIPTION
`if (!Array.from)` doesn't work in IE11 where the actual polyfill is required.