### PR TITLE
hiding tab scrollbar in Edge/IE browsers

### DIFF
--- a/src/shared/components/tab/tab.css
+++ b/src/shared/components/tab/tab.css
@@ -5,6 +5,7 @@
   width: 100%;
   margin: 0;
   padding-left: 0;
+  -ms-overflow-style: none;
 
   &::-webkit-scrollbar {
     display: none;


### PR DESCRIPTION
hide tab scrollbar in Edge/IE browsers