### PR TITLE
adding skip-to-main-content link in navbar

### DIFF
--- a/src/bring/components/navbar/Navbar.md
+++ b/src/bring/components/navbar/Navbar.md
@@ -27,6 +27,7 @@
           <use xlink:href="#logo-bring-gray"></use>
         </svg>
       </a>
+      <a class="hw-navbar__skip-to-content" href="#">Skip to main content</a>
 
       <nav class="hw-navbar__menu">
         <button class="hw-navbar__search-button" data-hw-toggle-search>

--- a/src/shared/components/navbar/navbar.css
+++ b/src/shared/components/navbar/navbar.css
@@ -85,6 +85,28 @@
     }
   }
 
+  &__skip-to-content {
+    top: 0;
+    left: 0;
+    opacity: 0;
+    padding: var(--hw-spacing-smaller);
+    position: absolute;
+    outline-offset: calc(-1 * var(--hw-spacing-smaller));
+    font-size: var(--hw-font-size-small);
+    z-index: var(--z-index--navbar);
+    color: var(--hw-color-primary);
+
+    &:active, &:focus {
+      top: var(--hw-navbar-height-mobile);
+      background-color: var(--hw-color-white);
+      opacity: 1;
+      transition: top .1s ease-in, background .5s linear;
+      @media (--large) {
+        top: var(--hw-navbar-height-desktop);
+      }
+    }
+  }
+
   &__menu {
     display: flex;
   }


### PR DESCRIPTION
Adding skip-to-main-content link in navbar after Logo
It gets the second Tab Order after Logo