### PR TITLE
Allow loading assets on external sites from documentation

### DIFF
--- a/server.js
+++ b/server.js
@@ -31,6 +31,12 @@ build.use((req, res, next) => {
   next();
 });
 
+docs.use((req, res, next)=> {
+  res.header('Access-Control-Allow-Origin', '*');
+  res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
+  next();
+});
+
 /**
  * Start build and assets folders
  */


### PR DESCRIPTION
This is hard to test locally, since the issue only appears on Heroku. Hopefully this will work.