### PR TITLE
On init, resize accordion if already initialised

### DIFF
--- a/src/shared/components/accordion/accordion.js
+++ b/src/shared/components/accordion/accordion.js
@@ -140,6 +140,7 @@ export const HWAccordion = ({
     SETTINGS.elements.forEach((accordion) => {
       // Skip if already initialised
       if (accordion.getAttribute('data-hw-accordion-initialised') === 'true') {
+        resizeAccordion();
         return false;
       }
 


### PR DESCRIPTION
In react, sometimes the accordion content doesn't expand to content's height.