### PR TITLE
Expose init method for navbar

### DIFF
--- a/src/shared/components/navbar/navbar.js
+++ b/src/shared/components/navbar/navbar.js
@@ -9,7 +9,7 @@ import trapFocus from '../../utilities/js/trapFocus';
  * @param {object} settings
  */
 
-const HWNavbar = ({
+export const HWNavbar = ({
   navbarSelector = '.hw-navbar',
   menuButtonSelector = '[data-hw-toggle-menu]',
   searchButtonSelector = '[data-hw-toggle-search]',


### PR DESCRIPTION
This is required in the react applications to initialize the component as there is usually a delay or the component is loaded after the init in main.js is run.