### PR TITLE
Rename Banner to Warning banner

### DIFF
--- a/src/shared/components/warning-banner/Warning-banner.md
+++ b/src/shared/components/warning-banner/Warning-banner.md
@@ -10,16 +10,16 @@
 
 ### Markup
 ```code   
-[Base]               .hw-banner;
+[Base]               .hw-warning-banner;
 
 Modifiers:
-[Expanded]            .hw-banner--expanded;
+[Expanded]            .hw-warning-banner--expanded;
 ```
 
 ### Data attributes
 ```code
 Required:
-[data-hw-banner="name"]   name of toggle (must be unique, used for aria-roles)
+[data-hw-warning-banner="name"]   name of toggle (must be unique, used for aria-roles)
 
 ```
 
@@ -27,30 +27,30 @@ Required:
 
 
 
-### Banner
+### Warning Banner
 
 ```html|plain,light
-  <section class="hw-banner" data-hw-banner="example1">
-    <button class="hw-banner__trigger">
-      <span class="hw-banner__text">
+  <section class="hw-warning-banner" data-hw-warning-banner="example1">
+    <button class="hw-warning-banner__trigger">
+      <span class="hw-warning-banner__text">
         All traffic in Norway is on hold due to the heat wave
       </span>
-      <i class="fas fa-chevron-down" data-fa-transform="down-2" title="Open banner information"></i>
+      <i class="fas fa-chevron-down" data-fa-transform="down-2" title="Open warning-banner information"></i>
     </button>
-    <div class="hw-banner__contents">
+    <div class="hw-warning-banner__contents">
       The asphalt on the roads is melting and our vehicles are stuck in thick oil. Drone deliveries operating as normal.
-      <a href="#" class="hw-banner__read-more-link">Read more</a>
+      <a href="#" class="hw-warning-banner__read-more-link">Read more</a>
     </div>
   </section>
 ```
 
 
 
-### Banner with no expand section
+### Warning Banner with no expand section
 #### Plain text
 ```html|plain,light
-<section class="hw-banner" data-hw-banner="example1">
-  <span class="hw-banner__text">
+<section class="hw-warning-banner" data-hw-warning-banner="example1">
+  <span class="hw-warning-banner__text">
     All traffic in Norway is on hold due to the heat wave
   </span>
 </section>
@@ -58,8 +58,8 @@ Required:
 
 #### Link
 ```html|plain,light
-<section class="hw-banner" data-hw-banner="example1">
-  <span class="hw-banner__text">
+<section class="hw-warning-banner" data-hw-warning-banner="example1">
+  <span class="hw-warning-banner__text">
     <a href="https://example.com">All traffic in Norway is on hold due to the heat wave</a>
   </span>
 </section>
@@ -67,8 +67,8 @@ Required:
 
 #### Inline link
 ```html|plain,light
-<section class="hw-banner" data-hw-banner="example1">
-  <span class="hw-banner__text">
+<section class="hw-warning-banner" data-hw-warning-banner="example1">
+  <span class="hw-warning-banner__text">
     All traffic in Norway is on hold due to the heat wave. <a href="https://example.com">Read more</a>
   </span>
 </section>
@@ -94,14 +94,14 @@ Required:
 ```image
 plain: true
 span: 3
-src: "{assets}/img/{postenbring}/banner-types-1.png"
+src: "{assets}/img/{postenbring}/warning-banner-types-1.png"
 title: "Expand"
 description: "This banner shows a one-line heading by default, and expands when clicked, showing a short paragraph with information of the occurred event or subject. The expanded section can contain a link to a page for further reading."
 ```
 ```image
 plain: true
 span: 3
-src: "{assets}/img/{postenbring}/banner-types-2.png"
+src: "{assets}/img/{postenbring}/warning-banner-types-2.png"
 title: "No expand"
 description: "This banner shows a short sentence of information on one line, with no option to expand. The banner can be static or contain links for further reading."
 ```
@@ -114,7 +114,7 @@ description: "This banner shows a short sentence of information on one line, wit
 ```image
 plain: true
 span: 3
-src: "{assets}/img/{postenbring}/banner-do-1.png"
+src: "{assets}/img/{postenbring}/warning-banner-do-1.png"
 description: "Keep the information short and clear, and include a link to a separate page with all the information and details for users to read."
 ```
 
@@ -123,6 +123,6 @@ description: "Keep the information short and clear, and include a link to a sepa
 ```image
 plain: true
 span: 3
-src: "{assets}/img/{postenbring}/banner-dont-1.png"
+src: "{assets}/img/{postenbring}/warning-banner-dont-1.png"
 description: "Do not add multiple levels of nested expanding sections in a banner."
 ```

--- a/src/shared/components/warning-banner/warning-banner.css
+++ b/src/shared/components/warning-banner/warning-banner.css
@@ -141,11 +141,7 @@
     &--expanded .hw-warning-banner__contents {
       /* Visible state */
       display: block;
-    }
-  
-    &--read-more-expanded .hw-warning-banner__read-more-contents {
-      display: block;
-    }
+    }  
   }
   
   /**

--- a/src/shared/components/warning-banner/warning-banner.css
+++ b/src/shared/components/warning-banner/warning-banner.css
@@ -1,0 +1,162 @@
+/**
+ * Block
+ */
+
+ .hw-warning-banner {
+    display: block;
+    color: var(--hw-color-black);
+    background-color: var(--hw-color-gray-normal);
+    position: relative;
+  
+    display: block;
+    width: 100%;
+    padding: var(--hw-spacing-small-3);
+    border: 0;
+    color: var(--hw-color-black);
+    text-align: center;
+    background-color: var(--hw-color-alert-yellow);
+  
+    font-size: var(--hw-font-size-smaller);
+  
+    transition: all var(--hw-transition-time-normal) var(--hw-transition-easing-normal);
+  
+    a {
+      font-size: var(--hw-font-size-smaller);
+      text-decoration: underline;
+    }
+  
+    /**
+     * Elements
+     */
+  
+    &__trigger {
+      background: transparent;
+      border: none;
+      outline: 0;
+  
+      font-family: var(--hw-font-primary-medium);
+      font-size: var(--hw-font-size-smaller);
+  
+      a {
+        font-family: var(--hw-font-primary-medium);
+        font-size: var(--hw-font-size-smaller);
+        text-decoration: underline;
+      }
+  
+      &:hover,
+      &:active,
+      &:focus {
+        color: var(--hw-color-black);
+        fill: var(--hw-color-black);
+      }
+    }
+  
+    &__trigger svg {
+      left: 50%;
+      bottom: -14px;
+      width: 12px;
+      fill: var(--hw-color-gray-dark);
+      z-index: 2;
+  
+      position: static;
+      margin-left: var(--hw-spacing-small-3);
+      transform: none;
+    }
+  
+    &__trigger-close {
+      background-color: transparent;
+      display: block;
+      width: 100%;
+      margin: 0 auto;
+      opacity: 0.5;
+      border: 0;
+      cursor: pointer;
+  
+      & svg {
+        fill: var(--hw-color-black);
+      }
+  
+      &:hover,
+      &:focus {
+        outline: 0;
+        opacity: 1;
+      }
+    }
+  
+    &__contents {
+      overflow: hidden;
+      padding: var(--hw-spacing-small-4);
+      padding-bottom: 0;
+  
+      /* Invisible state */
+      display: none;
+  
+      background-color: var(--hw-color-alert-yellow);
+      text-align: center;
+      font-family: var(--hw-font-primary-regular);
+      font-size: var(--hw-font-size-smaller);
+  
+      transition: all var(--hw-transition-time-normal) var(--hw-transition-easing-normal);
+  
+      a {
+        color: var(--hw-color-black);
+      }
+    }
+  
+    &__subtitle {
+      @extend .hw-text-lead;
+  
+      max-width: var(--hw-width-default);
+      margin: var(--hw-spacing-small-4) auto 0 auto;
+      color: var(--hw-color-black);
+    }
+  
+    &__text {
+      color: var(--hw-color-black);
+  
+      a {
+        color: var(--hw-color-black);
+      }
+    }
+  
+    &__read-more-link {
+      display: block;
+      position: relative;
+      margin-top: var(--hw-spacing-small-4);
+      font-size: var(--hw-font-size-small);
+      z-index: 1;
+    }
+  
+    /**
+     * Modifiers
+     */
+  
+    &--expanded .hw-warning-banner__trigger {
+      /*display: none;*/
+      .fa-chevron-down {
+        transform: rotate(180deg);
+      }
+    }
+  
+    &--expanded .hw-warning-banner__contents {
+      /* Visible state */
+      display: block;
+    }
+  
+    &--read-more-expanded .hw-warning-banner__read-more-contents {
+      display: block;
+    }
+  }
+  
+  /**
+    * no-js fallbacks
+    */
+  
+  .no-js .hw-warning-banner__contents {
+    display: block;
+  }
+  
+  .no-js .hw-warning-banner__read-more-contents {
+    display: block;
+  }
+  

--- a/src/shared/components/warning-banner/warning-banner.js
+++ b/src/shared/components/warning-banner/warning-banner.js
@@ -1,0 +1,102 @@
+/* global window */
+
+import q from '../../utilities/js/q';
+import qa from '../../utilities/js/qa';
+import findParent from '../../utilities/js/findParent';
+
+/**
+ * @function HWWarningBanner
+ * @version 0.0.1
+ * @desc Creates warning banner
+ * @param {object} settings
+ */
+const HWWarningBanner = ({
+  warningBannerSelector = '[data-hw-warning-banner]',
+  activeItemClass = 'hw-warning-banner--expanded',
+} = {}) => {
+
+  // Module settings object
+  const SETTINGS = {
+    elements: qa(warningBannerSelector), // All warning banner DOM nodes
+  };
+
+  /**
+   * @function toggleWarningBanner
+   * @desc Toggles the contents for a toggle
+   * @param {Event} e
+   */
+  function toggleWarningBanner(e) {
+    // Determine if we've clicked on an option
+    const elem = e.target;
+
+    // Find container and elem
+    const container = findParent({
+      selector: '[data-hw-warning-banner]',
+      elem
+    });
+    const contents = q('.hw-warning-banner__contents', container);
+
+    // Display/hide banner
+    if (contents.getAttribute('aria-hidden') === 'false') {
+      contents.setAttribute('aria-hidden', true);
+      elem.setAttribute('aria-expanded', false);
+      container.classList.remove(activeItemClass);
+    } else {
+      contents.setAttribute('aria-hidden', false);
+      elem.setAttribute('aria-expanded', true);
+      container.classList.add(activeItemClass);
+    }
+  }
+
+  /**
+   * @function bindToggleEvents
+   * @desc Adds listener to warning banner
+   * @param {node} trigger
+   */
+  function bindToggleEvents(trigger) {
+    trigger.addEventListener('click', toggleWarningBanner);
+  }
+
+  /**
+   * @function init
+   * @desc Initialises the warning banner
+   */
+  function init() {
+    // Check if any warning banners exist, return if not.
+    if (SETTINGS.elements.length < 1) {
+      return;
+    }
+
+    // Loop through all banners and initialise each
+    SETTINGS.elements.forEach((banner) => {
+      // Skip if already initialised
+      if (banner.getAttribute('data-hw-warning-banner-initialised') === 'true') {
+        return false;
+      }
+
+      // Mark as initialised
+      banner.setAttribute('data-hw-warning-banner-initialised', true);
+
+      // Find elements
+      const trigger = q('.hw-warning-banner__trigger', banner);
+      const contents = q('.hw-warning-banner__contents', banner);
+
+      if (trigger && contents) {
+        // Find warning banner name
+        const warningBannerName = banner.getAttribute('data-hw-warning-banner');
+
+        // Apply aria-roles
+        trigger.setAttribute('aria-controls', `warning-banner-${warningBannerName}`);
+        contents.setAttribute('id', `warning-banner-${warningBannerName}`);
+
+        // Set up event listeners for opening banner
+        bindToggleEvents(trigger);
+      }
+    });
+  }
+
+  // Initialise HWBanner component
+  init();
+};
+
+HWWarningBanner();


### PR DESCRIPTION
Leave existing banner.css and banner.js, since there are many projects that still uses the Banner component.

hw-banner is used the following places:

- https://github.com/bring/tracking-frontend/blob/master/frontend/src/test/components/__snapshots__/ApplicationBanner.test.js.snap
- https://github.com/bring/e-porto/blob/master/frontend/digitalstamp/src/pages/dummy/Debug.js
- https://github.com/bring/norgespakke-liten/blob/master/frontend/src/components/Debug.tsx
- https://github.com/bring/kp-suite/blob/master/hedwig-commons/src/main/resources/site/parts/banner/banner.html
- https://github.com/bring/pmo-web-components/blob/master/library/src/components/pmo/ApplicationMessage/__snapshots__/ApplicationMessageBanner.test.tsx.snap
- https://github.com/bring/sende-express/blob/master/frontend/src/components/Debug.tsx
- https://github.com/bring/pmo-web-components/blob/master/library/src/components/pmo/ApplicationMessage/ApplicationMessageBanner.tsx
- https://github.com/bring/tracking-frontend/blob/master/frontend/src/components/ApplicationBanner.js
- https://github.com/bring/tracking-frontend/blob/master/src/main/resources/enonic.posten.no.no.backup
