### PR TITLE
:wrench: set bring `h1` and `h1-display` to Posten Sans Medium, not Regular

### DIFF
--- a/src/bring/_config/variables.css
+++ b/src/bring/_config/variables.css
@@ -54,8 +54,8 @@
   /**
    * Font families
    */
-  --hw-h1-large-font-family: var(--hw-font-primary-regular);
-  --hw-h1-font-family: var(--hw-font-primary-regular);
+  --hw-h1-large-font-family: var(--hw-font-primary-medium);
+  --hw-h1-font-family: var(--hw-font-primary-medium);
   --hw-h2-font-family: var(--hw-font-primary-regular);
   --hw-h3-font-family: var(--hw-font-primary-regular);
   --hw-h4-font-family: var(--hw-font-primary-regular);


### PR DESCRIPTION
Ref. [slack](https://posten.slack.com/archives/G01AD31F1QC/p1715779820130709?thread_ts=1715777161.100359&cid=G01AD31F1QC)